### PR TITLE
fix(smart-battery): stop balancing on temp pause; red LED=6; gate start

### DIFF
--- a/firmware/smart-battery/SOFTWARE_DESIGN.md
+++ b/firmware/smart-battery/SOFTWARE_DESIGN.md
@@ -83,6 +83,7 @@ Notes: LED tasks do not synchronize phases across colors; each keeps its own 3 s
   - 3 pulses: SCD (short‑circuit discharge).
   - 4 pulses: OCD (over‑current discharge).
   - 5 pulses: AFE internal temp/reference abnormal or other major unclassified fault.
+  - 6 pulses: Battery temperature out of band (temp pause by BQ76920).
 
 ### 3.4 Blue (Global State)
 
@@ -100,8 +101,8 @@ Notes: LED tasks do not synchronize phases across colors; each keeps its own 3 s
 ## 4) Arbitration & Timing Composition
 
 - Per‑LED priority: Dropout 1 Hz > Fault 50% (1.5 s/1.5 s) + pulses > Base + pulses.
-- Green’s I2C pulse is asynchronous and can briefly override for ~30–240 ms without changing the 3 s phase.
-- Driver layer composes modes; semantic layer only decides “base + pulses / 50% blink / 1 Hz blink”.
+  - Green’s I2C pulse is asynchronous and can briefly override for ~30–240 ms without changing the 3 s phase.
+  - Driver layer composes modes; semantic layer only decides “base + pulses / 50% blink / 1 Hz blink”.
 
 ## 5) Sampling Cadence, Balancing, Pause‑Charge
 

--- a/firmware/smart-battery/src/bq76920_task.rs
+++ b/firmware/smart-battery/src/bq76920_task.rs
@@ -793,8 +793,10 @@ pub async fn bq76920_task(args: Bq76920TaskArgs) {
 
         // Determine if we should request CV hold from charger
         let hw_balancing_active = last_cellbal_bits != 0;
-        // Charger should hold CV when balancing is required or active, but only when AC is present.
+        // Charger should hold CV when balancing is required or active, but only when AC is present
+        // and not during temperature pause.
         let mut require_cv = adapter_present
+            && !temp_pause_active
             && (active_balancing_cell.is_some()
                 || hw_balancing_active
                 || balancing_needed_by_delta);
@@ -812,7 +814,8 @@ pub async fn bq76920_task(args: Bq76920TaskArgs) {
             // 3600 seconds = 1 hour
             if !TEST_FORCE_BQ_FETS_OFF {
                 // Strict policy: balancing only allowed when adapter is present.
-                let balancing_env = adapter_present;
+                // Additionally, never allow balancing during temperature pause.
+                let balancing_env = adapter_present && !temp_pause_active;
                 if balancing_env && charging_phase {
                     execute_smart_battery_balancing(
                         &mut bq,
@@ -831,6 +834,16 @@ pub async fn bq76920_task(args: Bq76920TaskArgs) {
             balance_timer_counter = 0; // Reset counter after execution
         }
         // --- End Battery Balancing Logic ---
+
+        // If temperature pause becomes active while balancing, stop immediately.
+        if temp_pause_active && (active_balancing_cell.is_some() || last_cellbal_bits != 0) {
+            defmt::info!("bal:stop temp_pause hw=0x{:02X}", last_cellbal_bits);
+            let _ = bq.set_cell_balancing(0).await;
+            active_balancing_cell = None;
+            last_cellbal_bits = 0;
+            // During temp pause we also withdraw CV request to avoid keeping charge path primed.
+            require_cv = false;
+        }
 
         // If adapter lost while balancing, stop immediately (log once until recovery)
         // 在暂停环境下（OV/严重不均衡），即使 adapter 不在也不立即停均衡

--- a/firmware/smart-battery/src/leds4_task.rs
+++ b/firmware/smart-battery/src/leds4_task.rs
@@ -162,7 +162,6 @@ pub async fn leds_task(
 
         // Red (BQ FET/Protection)
         let mut red = LedIntent::default();
-        let both_on = bq_fets_both_on(&bq);
         let red_active = (state_flags & sbits::ACTIVE_BQ) != 0;
         red.base_on = red_active;
         // Fault blink mapping：电池故障 → 50% 闪烁；并按严重度分配脉冲数（越严重脉冲数越大）

--- a/firmware/smart-battery/src/leds4_task.rs
+++ b/firmware/smart-battery/src/leds4_task.rs
@@ -99,6 +99,7 @@ pub async fn leds_task(
     let mut sc_pause_imb = false;
     let mut bq_fault = false;
     let mut overlay_balancing = false;
+    let mut temp_pause_active = false; // from BQ (BalancingCvRequest)
 
     loop {
         let now = Instant::now();
@@ -138,6 +139,7 @@ pub async fn leds_task(
         }
         if let Some(b) = bal_cv_sub.try_next_message_pure() {
             overlay_balancing = b.overlay;
+            temp_pause_active = b.temp_pause;
         }
         // Dropout derived from online flags: device stays online after boot probe
         // and only turns offline on real communication timeout thereafter.
@@ -177,9 +179,13 @@ pub async fn leds_task(
         if overlay_balancing {
             red.pulses = red.pulses.max(1);
         }
-        if !both_on {
-            red.pulses = red.pulses.max(5);
+        // Report temperature pause via Red LED with a dedicated code (6 pulses).
+        if temp_pause_active {
+            red.pulses = red.pulses.max(6);
         }
+        // Note: do NOT assign extra pulses when FETs are not both ON.
+        //       Base_on already reflects FET gating (any side OFF → base ON),
+        //       to avoid mixing with temperature indication.
 
         // Yellow (SC8815)
         let yellow_active = (state_flags & sbits::ACTIVE_SC) != 0;

--- a/firmware/smart-battery/src/leds4_task.rs
+++ b/firmware/smart-battery/src/leds4_task.rs
@@ -58,16 +58,7 @@ fn compose_with_pulses(base_on: bool, pulses: u8, phase_ms: u32) -> bool {
     base_on
 }
 
-fn bq_fets_both_on<const N: usize>(
-    bq_opt: &Option<crate::data_types::Bq76920Measurements<N>>,
-) -> bool {
-    if let Some(bq) = bq_opt.as_ref() {
-        use bq769x0_async_rs::registers::SysCtrl2Flags;
-        let m = bq.core_measurements.mos_status.0;
-        return m.contains(SysCtrl2Flags::CHG_ON) && m.contains(SysCtrl2Flags::DSG_ON);
-    }
-    false
-}
+// Note: FET gating状态仅通过 red.base_on 表达；不再需要单独判定“both_on”作为脉冲编码输入。
 
 /// 4-LED status compositor
 #[embassy_executor::task]

--- a/firmware/smart-battery/src/sc8815_task.rs
+++ b/firmware/smart-battery/src/sc8815_task.rs
@@ -530,9 +530,11 @@ pub async fn sc8815_task(args: Sc8815TaskArgs) {
                 }
 
                 // Charge start conditions (edge-logged)
+                // 当处于温度暂停时，严格禁止进入启动路径，避免启停抖动与日志刷屏
                 let pol_start_cond = pack_voltage_mv < PACK_CHARGE_START_THRESHOLD_MV
                     && !charger_active
-                    && adapter_holdoff_secs == 0;
+                    && adapter_holdoff_secs == 0
+                    && !temp_pause_cmd;
                 if pol_start_cond {
                     // (edge latch removed)
                     if sc8815_session.is_none() {
@@ -570,6 +572,7 @@ pub async fn sc8815_task(args: Sc8815TaskArgs) {
                         && uv_pause_secs == 0
                         && oc_pause_secs == 0
                         && !imbalance_pause_active
+                        && !temp_pause_cmd
                     {
                         if let Some(sess) = sc8815_session.as_mut() {
                             sess.enable_power_stage();


### PR DESCRIPTION
Summary
- Stop cell balancing during temperature pause and withdraw CV requests.
- Red LED uses dedicated 6‑pulse code for temperature pause; avoid overlap with FET gating indication.
- Gate SC8815 charge start and power-stage enable while temp pause is active to prevent periodic "start vb=..." thrash.

Details
- bq76920_task.rs
  - Block entering balancing when `temp_pause_active=true`.
  - Immediately stop active HW balancing on temp pause (`bal:stop temp_pause ...`).
  - Do not request CV hold during temp pause.
- leds4_task.rs
  - Red LED: 6 pulses = temperature pause (from BQ BalancingCvRequest.temp_pause).
  - Remove previous implicit pulse mapping when FETs not both ON (base level already indicates FET gating).
- sc8815_task.rs
  - Add `!temp_pause_cmd` to `pol_start_cond` and to the power-stage enable branch to prevent enable attempts during temp pause.
- SOFTWARE_DESIGN.md
  - Update Red LED codebook: 6 pulses = temperature pause; keep 5 pulses for AFE internal temp/reference abnormal.

Motivation
- During temp pause the charger power stage must remain off, balancing should stop, and LED indication should be unambiguous.
- Prior behavior retried enable every 100 ms during temp pause, producing repeated `start vb=...` logs.

Testing Notes
- Hardware: STM32L051C8T6 board + SC8815 charger + BQ76920 pack.
- Build/Run: `make -C firmware/smart-battery build` and `run`.
- Observations from logs:
  - Temp pause asserted: `[WARN] sc:req temp_pause t001c=50xx`.
  - Balancing stops immediately: `bal:stop temp_pause hw=0x..`.
  - No repeated `start vb=...` during the pause window.
  - Temp pause cleared: `[INFO] sc:req temp_pause clr t001c=49xx`; charging resumes once conditions satisfied.
- LED:
  - Red LED shows 6 short pulses per 3 s cycle during temp pause.
  - Blue LED shows 3 pulses for "charging paused" (global state), as designed.

Risk/Impact
- Behavior change limited to temp-pause window; normal charging/balancing unchanged.
- LED semantics clarified; documentation updated accordingly.

Checklist
- [x] Compiles for `thumbv6m-none-eabi` (release)
- [x] Design doc updated
- [x] Conventional commits

Please review. I can add more diagnostics or adjust hysteresis/backoff if needed.