### PR TITLE
chore(just): add default help and agentd-init

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,8 +1,44 @@
 set shell := ["/bin/sh", "-c"]
 
+# List available recipes (default)
+default:
+	@if just --list --unsorted >/dev/null 2>&1; then \
+	  just --list --unsorted; \
+	else \
+	  just --list; \
+	fi
+
+# Alias of `default`
+help: default
+
+# Alias of `default`
+list: default
+
 # Generic agentd passthrough
 agentd +args:
 	mcu-agentd {{args}}
+
+# Install mcu-agentd/mcu-managerd from a local checkout.
+_agentd-install path="":
+	set -eu; \
+	REPO="{{path}}"; \
+	if [ -z "$REPO" ]; then REPO="${MCU_AGENTD_PATH:-../mcu-agentd}"; fi; \
+	if [ ! -d "$REPO" ]; then \
+	  echo "mcu-agentd repo not found at: $REPO"; \
+	  echo "Usage: just agentd-init path=/path/to/mcu-agentd"; \
+	  echo "   or: MCU_AGENTD_PATH=/path/to/mcu-agentd just agentd-init"; \
+	  exit 2; \
+	fi; \
+	cargo install --force --path "$REPO" --bins; \
+	mcu-agentd --version; \
+	mcu-managerd --version
+
+agentd-init path="":
+	@just agentd stop >/dev/null 2>&1 || true
+	@just _agentd-install path="{{path}}"
+	@just agentd-start
+
+agnetd-init: agentd-init
 
 agentd-start:
 	just agentd start
@@ -12,9 +48,6 @@ agentd-status:
 
 agentd-stop:
 	just agentd stop
-
-managerd-project-add:
-	mcu-managerd projects add .
 
 agentd-web:
 	mcu-agentd web

--- a/docs/mcu-agentd.md
+++ b/docs/mcu-agentd.md
@@ -17,7 +17,15 @@
 - 全局安装（产物在 `$HOME/.cargo/bin`，确保在 `PATH` 中）：
 
   ```bash
-  cargo install --path /Users/ivan/Projects/Ivan/mcu-agentd --bins
+  cargo install --path ../mcu-agentd --bins
+  ```
+
+  或使用本仓库的 `just` 封装（强制安装 + 自动启动）：
+
+  ```bash
+  just agentd-init
+  # or: just agentd-init path=../mcu-agentd
+  # or: MCU_AGENTD_PATH=../mcu-agentd just agentd-init
   ```
 
 校验：
@@ -99,12 +107,6 @@ mcu-agentd selector get stm32
 
 ## 项目注册与 Web UI
 
-首次使用需显式注册项目（支持多项目切换与资源仲裁）：
-
-```bash
-mcu-managerd projects add .
-```
-
 打开 Web UI：
 
 ```bash
@@ -155,6 +157,6 @@ mcu-agentd monitor stm32 --from-start
 ## 验收标准（迁移完成后）
 
 - `mcu-agentd config validate` 在仓库根执行成功。
-- `mcu-managerd projects add .` 注册成功，`mcu-agentd web` 可打开 Web UI，并能切换到 `ups120`。
+- `mcu-agentd start` 启动成功，`mcu-agentd web` 可打开 Web UI，并能切换到 `ups120`。
 - ESP32/STM32 的 selector 可写入 `.esp32-port`/`.stm32-port` 并被 `mcu-agentd selector get` 正确读回。
 - `mcu-agentd flash/reset/monitor/logs` 对 `esp32` 与 `stm32` 均可用，且日志落盘到 `./.mcu-agentd/`。

--- a/docs/software/mcu-agentd-migration.md
+++ b/docs/software/mcu-agentd-migration.md
@@ -2,7 +2,7 @@
 
 ## 背景
 
-`ups120` 仓库历史上维护过一套项目内自研的 `ups120-agentd`（位于 `tools/` 下的 `mcu-agentd` 子项目），用于统一执行 ESP32/STM32 的烧录、复位与日志采集。该实现与外部项目 `/Users/ivan/Projects/Ivan/mcu-agentd` 的能力与维护节奏发生分叉，导致重复维护与行为不一致风险。
+`ups120` 仓库历史上维护过一套项目内自研的 `ups120-agentd`（位于 `tools/` 下的 `mcu-agentd` 子项目），用于统一执行 ESP32/STM32 的烧录、复位与日志采集。该实现与外部项目 `../mcu-agentd` 的能力与维护节奏发生分叉，导致重复维护与行为不一致风险。
 
 本工作项将 `ups120` 的 on-target 工作流切换到外部 `mcu-agentd`/`mcu-managerd`，并移除仓库内的自研实现。
 
@@ -10,7 +10,7 @@
 
 - 统一入口：`ups120` 的 flash/reset/monitor/logs/selector 统一通过外部 `mcu-agentd` 执行。
 - 保留现有端口/探针缓存习惯：ESP32 使用 `.esp32-port`，STM32 使用 `.stm32-port`。
-- 使用 Web UI：通过 `mcu-managerd` 注册项目并提供 Web UI/HTTP API 入口。
+- 使用 Web UI：通过 `mcu-agentd` 启动时自动注册项目并提供 Web UI/HTTP API 入口。
 - 移除遗留实现与垃圾内容：删除 `tools/mcu-agentd/`，并删除旧版 STM32 probe selector 缓存文件（不再生成/读取）。
 
 ## 非目标
@@ -29,9 +29,7 @@
 - 迁移 `just` 包装：
   - 保留 `sb-*` 与 `ups-*` 命令作为主入口。
   - `agentd-*` 命令语义与外部工具对齐（selector/web/config validate 等）。
-- 项目注册与 Web UI 工作流落地：
-  - `mcu-managerd projects add .`
-  - `open "$(mcu-agentd web)"`
+- Web UI 工作流落地：`open "$(mcu-agentd web)"`
 - 清理遗留：
   - 删除 `tools/mcu-agentd/`
   - 删除旧版 STM32 probe selector 缓存文件，并确保脚本/文档不再引用它
@@ -45,12 +43,11 @@
 
 ### 1) 首次使用（一次性）
 
-1. 全局安装外部工具：
-   - `cargo install --path /Users/ivan/Projects/Ivan/mcu-agentd --bins`
+1. 全局安装外部工具并启动 daemon：
+   - `just agentd-init`
 2. 在仓库根创建并校验 `mcu-agentd.toml`：
    - `mcu-agentd config validate`
-3. 注册项目并打开 Web UI：
-   - `mcu-managerd projects add .`
+3. 打开 Web UI：
    - `open "$(mcu-agentd web)"`
 4. 设置 selector（建议显式指定 VALUE，避免交互模式的严格校验门槛）：
    - ESP32：`mcu-agentd selector set esp32 /dev/cu.usbmodemXXXX`
@@ -128,7 +125,7 @@
 
 - 配置与注册：
   - `mcu-agentd config validate` 在仓库根执行成功。
-  - `mcu-managerd projects add .` 注册成功，`open "$(mcu-agentd web)"` 可打开 Web UI 并切换到 `ups120`。
+  - `mcu-agentd start` 启动成功，`open "$(mcu-agentd web)"` 可打开 Web UI 并切换到 `ups120`。
 - 缓存文件：
   - `.esp32-port` / `.stm32-port` 可被 `mcu-agentd selector get` 正确读回。
   - 旧版 STM32 probe selector 缓存文件不存在，且仓库内无脚本/文档再引用它。


### PR DESCRIPTION
## Summary
- Make `just` default recipe print the recipe list (help)
- Add `agentd-init` to stop, force-install from a local checkout (default `../mcu-agentd`), then start
- Remove the old `managerd-project-add` entry and update docs to match

## Notes
- `agnetd-init` is kept as an alias for the requested name

## Testing
- `just` / `just help`